### PR TITLE
Fix minecraft home directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN chmod +x /start.sh
 RUN apt-get update && apt-get install -y wget git && apt-get clean all
 
 # Make special user for minecraft to run in
-RUN useradd -s /bin/bash -d /minecraft -m minecraft
+RUN useradd -s /bin/bash -d /data/minecraft -m minecraft
 
 # expose minecraft port
 EXPOSE 25565


### PR DESCRIPTION
spigot.jar wouldn't run because the home directory of minecraft
user was set to /minecraft but the spigot.jar was put in /data/minecraft
